### PR TITLE
Return when no coin name match is found on coincap

### DIFF
--- a/imports/commands/coincap.js
+++ b/imports/commands/coincap.js
@@ -8,7 +8,7 @@ module.exports = (client, message) => {
     message.channel.send(`Require command of the form "!coincap <COIN NAME>"`);
     return;
   }
-  
+
   if(!data[0] || !data[1]) {
     return;
   }
@@ -21,6 +21,7 @@ module.exports = (client, message) => {
     function (e, r, data) {
       if (Object.keys(data).length === 0) {
         message.channel.send(`Unable to find the coin ${coin}`);
+        return;
       }
 
       const {


### PR DESCRIPTION
Skip and don't print a coin report with undefined data.

-_-

```
undefined (undefined)
$0.00 (0.00000000Ƀ)  +/-: undefined%  Volume: $0.00
Supply: 0.00  Market Cap: $0.00
```