### PR TITLE
Suppress price reporting spam (subsequent CoZbot messages)

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -4,10 +4,17 @@ module.exports = class Bot {
   constructor(client, botApiKey) {
     this.botApiKey = botApiKey;
     this.client = client;
+
+    this.lastMessage = {};
+
+    this.retrieveLastMessage = () => {
+      return this.lastMessage;
+    }
   }
   
   init() {
     this.client.on('message', (message) => {
+      this.lastMessage = message;
       const regex = /^(how|when|is|which|what|whose|who|whom|where|why|can)(.*)|([^.!?]+\?)/igm;
       
       const isCommand = message.content.charAt(0) === '!';
@@ -30,7 +37,7 @@ module.exports = class Bot {
     
     this.client.on('ready', () => {
       const channel = this.client.channels.get('MARKET_PRICE_CHANNEL');
-      const marketUpdates = require('./imports/market-price-updates')(channel);
+      const marketUpdates = require('./imports/market-price-updates')(channel, this.retrieveLastMessage);
     })
   }
 };

--- a/bot.js
+++ b/bot.js
@@ -5,7 +5,7 @@ module.exports = class Bot {
     this.botApiKey = botApiKey;
     this.client = client;
 
-    this.lastMessage = {};
+    this.lastMessage = {author:{bot:false}};
 
     this.retrieveLastMessage = () => {
       return this.lastMessage;

--- a/imports/market-price-updates.js
+++ b/imports/market-price-updates.js
@@ -1,7 +1,7 @@
 const request = require('async-request');
 const currency = require('currency-formatter');
 
-async function sendUpdate(c) {
+async function sendUpdate(c, retrieveLastMessage) {
   try {
     console.log('GET MARKET PRICE!!!');
   
@@ -32,6 +32,13 @@ async function sendUpdate(c) {
     msg += ` - B ${currency.format(btcUSDPrice.lastPrice, {code: 'USD'})}`;
   
     console.log(msg);
+
+    const lastMessage = retrieveLastMessage();
+
+    if (lastMessage.author.bot) {
+      console.log('Deleting last message, as it was a price update')
+      lastMessage.delete();
+    }
   
     c.send(msg);
   } catch(e) {


### PR DESCRIPTION
CoZ is on fire when #market is mostly inactive. This can result in outcomes as pictured here:
![screen shot 2018-03-09 at 10 07 36 pm](https://user-images.githubusercontent.com/994683/37238960-524c185a-23e6-11e8-9612-0ec7a64bcd39.png)

This change stores and checks the last message posted to the channel for authorship by the bot, and if the bot was the last poster, it deletes that last price update before sending the new one.