### PR TITLE
Removed 'Unable to find provided coin' message

### DIFF
--- a/imports/commands/general/coincap.js
+++ b/imports/commands/general/coincap.js
@@ -26,7 +26,7 @@ module.exports = class CoincapCommand extends Command {
     const requestedCoin = getCoin(usersCoinInput);
 
     if (!requestedCoin) {
-      message.channel.send('Unable to find provided coin');
+      // message.channel.send('Unable to find provided coin');
       return;
     }
 
@@ -36,7 +36,7 @@ module.exports = class CoincapCommand extends Command {
       );
 
       if (!coinTicker || !coinTicker.data[0]) {
-        message.channel.send('Unable to find provided coin');
+        // message.channel.send('Unable to find provided coin');
         return;
       }
 


### PR DESCRIPTION
If provided coin to find for !coincap command is not found (for example if user did a typo), bot sends a message saying "Unable to find provided coin". It seems that it confuses users because messages which trigger that command are deleted - and everything other users see is this message without any context.

If user does a typo with this change - it will just fail silently.

Example:
<img width="614" alt="screen shot 2018-07-11 at 19 31 27" src="https://user-images.githubusercontent.com/8177587/42589397-1ee3b024-8541-11e8-8709-57a69aed62b7.png">