### PR TITLE
neo-services-monitor support channel updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img 
-    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png" 
+  <img
+    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png"
     width="125px"
   >
 </p>
@@ -61,6 +61,7 @@ module.exports = class NeoCommand extends Command {
 ## Settings explanation
  - `botToken` - Sets token of Discord bot.
  - `marketPriceChannel` - Market price details are posted on this channel.
+ - `supportChannel` - Neo service status updates are posted on this channel.
  - `reportChannel` - Report details are posted on this channel after reporting a user.
  - `ownersId` - Specifies which users has admin rights for bot - [command list for admins](https://github.com/discordjs/Commando/blob/master/docs/commands/builtins.md), [more details about user permissions](https://dragonfire535.gitbooks.io/discord-js-commando-beginners-guide/content/checking-for-user-permissions.html).
  - `botPrefix` - Sets custom prefix for all commands.

--- a/imports/neo-services-monitor.js
+++ b/imports/neo-services-monitor.js
@@ -1,0 +1,34 @@
+const request = require('async-request');
+
+async function sendUpdate(c) {
+  try {
+    console.log('Actively monitoring Neo Services: Neoscan MainNet');
+
+    var result = await request('https://neoscan.io/api/main_net/v1/get_height');
+
+    const neoscanBlockHeight = JSON.parse(result.body).height;
+
+    result = await request('https://neoscan.io/api/main_net/v1/get_block/' + neoscanBlockHeight);
+
+    const neoscanBlock = JSON.parse(result.body)
+
+    const neoscanBlockTime = new Date(neoscanBlock.time * 1000).toLocaleString()
+
+    let msg = '';
+    msg += ` Neoscan Height: ${neoscanBlockTime}`;
+    msg += ` Neoscan Last Block Time: ${neoscanBlockHeight}`;
+
+    console.log(msg);
+
+    c.send(msg);
+  } catch(e) {
+    console.log('ERROR', e.message);
+  }
+}
+
+module.exports = async (channel) => {
+  await sendUpdate(channel);
+  setInterval(async (c) => {
+    await sendUpdate(c);
+  }, 200000, channel);
+};

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const startBot = function() {
       console.log(`Client ready; logged in as ${client.user.username}#${client.user.discriminator} (${client.user.id})`);
       const channel = client.channels.get(settings.marketPriceChannel);
       const marketUpdates = require('./imports/market-price-updates')(channel);
+      const supportChannel = client.channels.get(settings.supportChannel);
+      const marketUpdates = require('./imports/neo-services-monitor')(supportChannel);
     })
     .on('error', console.error)
     .on('warn', console.warn)

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,7 @@
 module.exports = {
     botToken: '<PUT_TOKEN_HERE>',
     marketPriceChannel: '<PUT_CHANNEL_ID_HERE>',
+    supportChannel: '<PUT_CHANNEL_ID_HERE>',
     reportChannel: '<PUT_CHANNEL_ID_HERE>',
     ownersId: '<PUT_MEMBER_ID_HERE>', // example: 'ID' (string) or ['ID1', 'ID2'] (array)
     botPrefix: '<PUT_BOT_PREFIX_HERE>', // example: '!'


### PR DESCRIPTION
I've whipped up a quick sample of the neo-services-monitor system with support channel configruation option. The example only periodically updates (on the same frequency as market-price-updates)  the support channel with most recent block height and block time per neoscan but we can cater this information to be more useful and include other services. The thinking is that any new folks entering the support channel would have an immediate information outlet to help direct their questions around chain health and status. This could point them to more useful resources such as monitor.cityofzion.io or happnodes as well. I was considering using direct RPC calls also as these are well within capabilities but I demonstrated neoscan in the initial PR. Feedback appreciated! Thanks!

