### PR TITLE
neo-services-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img 
-    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png" 
+  <img
+    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png"
     width="125px"
   >
 </p>
@@ -61,6 +61,7 @@ module.exports = class NeoCommand extends Command {
 ## Settings explanation
  - `botToken` - Sets token of Discord bot.
  - `reportChannel` - Report details are posted on this channel after reporting a user.
+ - `supportChannel` - Periodic Neo service status updates are sent to this channel.
  - `ownersId` - Specifies which users has admin rights for bot - [command list for admins](https://github.com/discordjs/Commando/blob/master/docs/commands/builtins.md), [more details about user permissions](https://dragonfire535.gitbooks.io/discord-js-commando-beginners-guide/content/checking-for-user-permissions.html).
  - `botPrefix` - Sets custom prefix for all commands.
  - `autoReconnect` - Automatically reconnects the bot in case of connection issues.

--- a/imports/neo-services-updates.js
+++ b/imports/neo-services-updates.js
@@ -1,0 +1,33 @@
+const request = require('async-request');
+
+async function sendUpdate(c) {
+  try {
+    console.log('Actively monitoring Neo Services: Neoscan MainNet');
+
+    var result = await request('https://neoscan.io/api/main_net/v1/get_height');
+
+    const neoscanBlockHeight = JSON.parse(result.body).height;
+
+    result = await request('https://neoscan.io/api/main_net/v1/get_block/' + neoscanBlockHeight);
+
+    const neoscanBlock = JSON.parse(result.body)
+    const neoscanBlockTime = new Date(neoscanBlock.time * 1000).toLocaleString()
+
+    let msg = '';
+    msg += ` Neoscan Height: ${neoscanBlockTime}`;
+    msg += ` Neoscan Last Block Time: ${neoscanBlockHeight}`;
+
+    console.log(msg);
+
+    c.send(msg);
+  } catch(e) {
+    console.log('ERROR', e.message);
+  }
+}
+
+module.exports = async (channel) => {
+  await sendUpdate(channel);
+  setInterval(async (c) => {
+    await sendUpdate(c);
+  }, 200000, channel);
+};

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const {
 } = require('./settings');
 const { deleteMsg, fetchCoinDict } = require('./helpers');
 const marketUpdates = require('./imports/market-price-updates');
+const supportUpdates = require('./imports/neo-services-updates');
 const client = new CommandoClient({
   autoReconnect: autoReconnect,
   owner: ownersId,
@@ -32,8 +33,10 @@ const startBot = () => {
       await fetchCoinDict();
 
       const priceChannel = client.channels.get(marketPriceCommand.marketPriceChannel);
+      const supportChannel = client.channels.get(supportChannel);
 
       await marketUpdates(priceChannel);
+      await supportUpdates(supportChannel);
     })
     .on('error', console.error)
     .on('warn', console.warn)

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,7 @@
 module.exports = {
   botToken: '<PUT_TOKEN_HERE>',
   reportChannel: '<PUT_CHANNEL_ID_HERE>',
+  supportChannel: '<PUT_CHANNEL_ID_HERE>',
   ownersId: '<PUT_MEMBER_ID_HERE>', // example: 'ID' (string) or ['ID1', 'ID2'] (array)
   botPrefix: '<PUT_BOT_PREFIX_HERE>', // example: '!'
   autoReconnect: true,


### PR DESCRIPTION
 I've whipped up a quick sample of the neo-services-update system with support channel configuration option. The example only periodically updates the support channel with most recent block height and block time per neoscan but we can cater this information to be more useful and include other services. The thinking is that any new folks entering the support channel would have an immediate information outlet to help direct their questions around chain health and status. This could point them to more useful resources such as monitor.cityofzion.io or happnodes as well. I was considering using direct RPC calls also as these are well within capabilities but I demonstrated neoscan in this initial PR. Feedback appreciated! Thanks!